### PR TITLE
ci: do not use mise cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           install: true
-          cache: true
       - name: slangroom tests
         run: |
           ln -s `mise which slangroom-exec` bin/slangroom-exec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           install: true
+          cache: false
       - name: slangroom tests
         run: |
           ln -s `mise which slangroom-exec` bin/slangroom-exec


### PR DESCRIPTION
this will ensure that always the latest version of slangroom-exec
